### PR TITLE
Src/Options.hs: tweak (<>) import for optparse-applicative-0.13

### DIFF
--- a/Src/Options.hs
+++ b/Src/Options.hs
@@ -5,7 +5,7 @@ module Options
     ) where
 
 import Options.Applicative
-import Data.Monoid (mconcat)
+import Data.Monoid (mconcat, (<>))
 
 data Command =
       CmdGraph

--- a/cabal-db.cabal
+++ b/cabal-db.cabal
@@ -54,7 +54,7 @@ Executable           cabal-db
                    , utf8-string
                    , pretty
                    , process
-                   , optparse-applicative >= 0.11
+                   , optparse-applicative >= 0.13
                    , ansi-wl-pprint
   Buildable: True
 


### PR DESCRIPTION
Current hackage package fails to build as:
  Src/Options.hs:67:50: error:
    • Variable not in scope: (<>) :: Mod f9 a9 -> Mod f8 a8 -> t3
    • Perhaps you meant one of these:
        ‘<$>’ (imported from Options.Applicative),
        ‘<*>’ (imported from Options.Applicative),
        ‘*>’ (imported from Options.Applicative)
      Perhaps you want to add ‘<>’ to the import list in the import of
      ‘Data.Monoid’ (Src/Options.hs:8:1-28).

Signed-off-by: Sergei Trofimovich <siarheit@google.com>